### PR TITLE
fixed providerConfig issues

### DIFF
--- a/functions/awslbcontroller/main.k
+++ b/functions/awslbcontroller/main.k
@@ -23,10 +23,8 @@ _metadata = lambda name: str -> any {
 _defaults = {
     managementPolicies = params.managementPolicies or ["*"]
     if params.providerConfigName:
-        providerConfigRef = {
-            kind = "ProviderConfig"
-            name = params.providerConfigName
-        }
+        providerConfigName = params.providerConfigName or "default"
+
 }
 
 # Get cluster name from observed PodIdentity (only available after it's created)

--- a/tests/test-awslbcontroller/main.k
+++ b/tests/test-awslbcontroller/main.k
@@ -15,6 +15,7 @@ _items = [
                     metadata.name: "podidentity"
                     spec = {
                         parameters = {
+                            providerConfigName: "default"
                             region: "us-west-2"
                             serviceAccount = {
                                 name: "aws-load-balancer-controller"


### PR DESCRIPTION
### Description of your changes

Fix providerConfig bug blocking `platform-ref-aws`

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

`/control-plane-project:e2e-test-configuration`

```bash
● ✅ E2E Test: PASSED

  Test: e2etest-awslbcontroller
  Duration: ~18 minutes
  Control Plane: configuration-aws-lb-controller-uptest-e2etest-awslbcontroller

  Test Results

  ✅ All resources created successfully:
  - Network (VPC, Subnets, Internet Gateway, Security Groups, Route Tables)
  - EKS Cluster with Node Group
  - EKS Add-ons (VPC CNI, EBS CSI Driver, Pod Identity Agent)
  - IAM Roles (Control Plane, Node Group, EBS CSI Driver)
  - PodIdentity for AWS LB Controller
  - Helm Release for AWS LB Controller
  - All resources reached Ready state

  ✅ Cleanup: All 7 test resources deleted successfully

  Timeline

  - 00:00 - 00:03: Building & deploying configuration package
  - 00:03 - 00:06: Creating control plane & installing packages
  - 00:06 - 00:17: Resources provisioning (EKS cluster creation is time-intensive)
  - 00:17 - 00:18: Cleanup & control plane deletion
  ```
